### PR TITLE
Update github actions to use environment files

### DIFF
--- a/GITHUB_ACTIONS_UPGRADE_SUMMARY.md
+++ b/GITHUB_ACTIONS_UPGRADE_SUMMARY.md
@@ -1,0 +1,102 @@
+# GitHub Actions Deprecation Fix Summary
+
+## Issue Resolved ✅
+
+The deprecated `set-output` command warnings have been fixed by updating the `scripts/organize-components.mjs` file to use the new `GITHUB_OUTPUT` environment file syntax.
+
+## What Was Changed
+
+### Before (Deprecated):
+```javascript
+console.log('::set-output name=changes_made::' + (appliedMoves.length > 0 ? 'true' : 'false'));
+console.log('::set-output name=summary_path::' + summaryPath);
+console.log('::set-output name=markdown_path::' + markdownPath);
+```
+
+### After (Modern):
+```javascript
+const githubOutput = process.env.GITHUB_OUTPUT;
+if (githubOutput) {
+  const fs = await import('fs');
+  const output = [
+    `changes_made=${appliedMoves.length > 0 ? 'true' : 'false'}`,
+    `summary_path=${summaryPath}`,
+    `markdown_path=${markdownPath}`
+  ].join('\n');
+  fs.writeFileSync(githubOutput, output, 'utf8');
+}
+```
+
+## Files Updated
+
+- ✅ `scripts/organize-components.mjs` - Updated to use `GITHUB_OUTPUT`
+- ✅ `.github/workflows/organize-components.yml` - Already using modern syntax
+
+## Why This Change Was Necessary
+
+GitHub deprecated the `set-output` command on October 11, 2022, and it will be disabled soon. The new approach uses environment files (`GITHUB_OUTPUT`) which is more secure and efficient.
+
+## Benefits of the New Approach
+
+1. **Security**: Environment files are more secure than command-line output
+2. **Performance**: Better handling of special characters and multiline values
+3. **Future-proof**: Compliant with current GitHub Actions standards
+4. **Reliability**: More robust output handling
+
+## Verification
+
+- ✅ No more `set-output` commands found in the codebase
+- ✅ All workflow outputs are properly configured
+- ✅ Script outputs are correctly written to `GITHUB_OUTPUT`
+
+## Additional Recommendations
+
+### 1. Workflow Organization
+Consider organizing your workflows by:
+- **Feature-based**: Separate workflows for different types of tasks
+- **Environment-based**: Different workflows for staging, production, etc.
+- **Trigger-based**: Separate workflows for different triggers (push, PR, manual)
+
+### 2. Reusable Workflows
+Consider creating reusable workflows for common tasks:
+```yaml
+# .github/workflows/reusable-deploy.yml
+name: Reusable Deploy
+on:
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        type: string
+```
+
+### 3. Environment Protection
+Use GitHub Environments for sensitive deployments:
+```yaml
+environment:
+  name: production
+  url: https://your-app.com
+```
+
+### 4. Workflow Dependencies
+Organize job dependencies clearly:
+```yaml
+jobs:
+  test:
+    # ... test job
+  build:
+    needs: test
+    # ... build job
+  deploy:
+    needs: build
+    # ... deploy job
+```
+
+## Next Steps
+
+1. ✅ **Completed**: Fixed deprecated `set-output` commands
+2. 🔄 **Consider**: Review other workflows for similar issues
+3. 🔄 **Consider**: Implement workflow organization improvements
+4. 🔄 **Consider**: Add workflow testing and validation
+
+Your GitHub Actions workflows are now up-to-date and compliant with current standards! 🎉

--- a/scripts/organize-components.mjs
+++ b/scripts/organize-components.mjs
@@ -237,9 +237,16 @@ async function main() {
   
   // Output summary for GitHub Actions
   if (process.env.GITHUB_ACTIONS) {
-    console.log('::set-output name=changes_made::' + (appliedMoves.length > 0 ? 'true' : 'false'));
-    console.log('::set-output name=summary_path::' + summaryPath);
-    console.log('::set-output name=markdown_path::' + markdownPath);
+    const githubOutput = process.env.GITHUB_OUTPUT;
+    if (githubOutput) {
+      const fs = await import('fs');
+      const output = [
+        `changes_made=${appliedMoves.length > 0 ? 'true' : 'false'}`,
+        `summary_path=${summaryPath}`,
+        `markdown_path=${markdownPath}`
+      ].join('\n');
+      fs.writeFileSync(githubOutput, output, 'utf8');
+    }
   }
 }
 


### PR DESCRIPTION
Update GitHub Actions `set-output` commands to use `GITHUB_OUTPUT` environment files to resolve deprecation warnings.

This change addresses the deprecation of the `::set-output::` command in GitHub Actions, ensuring the workflow remains compliant and avoids future breakage when the old command is disabled.

---
<a href="https://cursor.com/background-agent?bcId=bc-27cb84cf-94df-410b-a541-0875ff2170e7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-27cb84cf-94df-410b-a541-0875ff2170e7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

