### PR TITLE
Display notes as workflow annotations

### DIFF
--- a/.github/workflows/organize-components.yml
+++ b/.github/workflows/organize-components.yml
@@ -16,8 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       changes_made: ${{ steps.organize.outputs.changes_made }}
-      summary_path: ${{ steps.organize.outputs.summary_path }}
-      markdown_path: ${{ steps.organize.outputs.markdown_path }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -42,15 +40,6 @@ jobs:
 
       - name: Update TOC (post)
         run: npm run update:toc
-
-      - name: Upload change summary artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: ai-changes-summary
-          path: |
-            ai-changes-summary.json
-            AI_CHANGES_SUMMARY.md
-          retention-days: 30
 
       - name: Generate commit message
         id: commit-msg
@@ -78,23 +67,94 @@ jobs:
           fi
 
       - name: Comment on commit
-        if: steps.organize.outputs.changes_made == 'true'
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
-            let summaryContent = '';
+            
+            // Read the detailed summary files
+            let summaryData = {};
+            let markdownContent = '';
+            
             try {
-              summaryContent = fs.readFileSync('AI_CHANGES_SUMMARY.md', 'utf8');
+              // Read JSON summary for structured data
+              const jsonContent = fs.readFileSync('ai-changes-summary.json', 'utf8');
+              summaryData = JSON.parse(jsonContent);
+              
+              // Read markdown for formatted display
+              markdownContent = fs.readFileSync('AI_CHANGES_SUMMARY.md', 'utf8');
             } catch (e) {
-              summaryContent = 'Change summary could not be read.';
+              console.log('Could not read summary files:', e.message);
+              // Provide fallback information
+              summaryData = {
+                timestamp: new Date().toISOString(),
+                changes: {
+                  moves: [],
+                  toc_sections: {},
+                  notes: ['Summary files could not be read, but the workflow completed successfully.']
+                }
+              };
             }
             
-            const comment = `🤖 **AI Component Organization Complete**
+            // Build a comprehensive comment with all information
+            let comment = `🤖 **AI Component Organization Complete**\n\n`;
             
-            ${summaryContent}
+            // Add timestamp
+            if (summaryData.timestamp) {
+              const timestamp = new Date(summaryData.timestamp).toLocaleString();
+              comment += `⏰ **Generated:** ${timestamp}\n\n`;
+            }
             
-            📋 **Artifacts**: Download the \`ai-changes-summary\` artifact to see detailed changes.`;
+            // Check if any changes were made
+            const hasChanges = summaryData.changes && (
+              (summaryData.changes.moves && summaryData.changes.moves.length > 0) ||
+              (summaryData.changes.toc_sections && Object.keys(summaryData.changes.toc_sections).length > 0)
+            );
+            
+            if (!hasChanges) {
+              comment += `ℹ️ **No structural changes were made**\n\n`;
+            }
+            
+            // Add component moves if any
+            if (summaryData.changes && summaryData.changes.moves && summaryData.changes.moves.length > 0) {
+              comment += `📁 **Component Moves:**\n`;
+              comment += `\n`;
+              for (const move of summaryData.changes.moves) {
+                const status = move.status === 'success' ? '✅' : '❌';
+                comment += `${status} \`${move.from}\` → \`${move.to}\`\n`;
+                if (move.error) {
+                  comment += `   - Error: ${move.error}\n`;
+                }
+              }
+              comment += '\n';
+            }
+            
+            // Add new TOC structure if any
+            if (summaryData.changes && summaryData.changes.toc_sections && Object.keys(summaryData.changes.toc_sections).length > 0) {
+              comment += `📋 **New Table of Contents Structure:**\n`;
+              comment += `\n`;
+              for (const [section, components] of Object.entries(summaryData.changes.toc_sections)) {
+                comment += `**${section}**\n`;
+                for (const component of components) {
+                  comment += `  • ${component}\n`;
+                }
+                comment += `\n`;
+              }
+            }
+            
+            // Add AI notes if any
+            if (summaryData.changes && summaryData.changes.notes && summaryData.changes.notes.length > 0) {
+              comment += `💡 **AI Insights & Recommendations:**\n`;
+              comment += `\n`;
+              for (const note of summaryData.changes.notes) {
+                comment += `• ${note}\n`;
+              }
+              comment += `\n`;
+            }
+            
+            // Add footer
+            comment += `---\n\n`;
+            comment += `📖 **Full Summary**: All changes and notes are displayed above. No artifacts to download!`;
             
             github.rest.repos.createCommitComment({
               owner: context.repo.owner,
@@ -102,3 +162,8 @@ jobs:
               commit_sha: context.sha,
               body: comment
             });
+
+      - name: Cleanup temporary files
+        if: always()
+        run: |
+          rm -f ai-changes-summary.json AI_CHANGES_SUMMARY.md

--- a/scripts/organize-components.mjs
+++ b/scripts/organize-components.mjs
@@ -50,7 +50,25 @@ async function readComponentDocs() {
 }
 
 function buildPrompt(structure, docs) {
-  return `You are an expert frontend architect. Given the components folder structure and docs, propose an improved organization (groupings like UI, data-display, feedback, navigation), and suggest safe renames/moves. Output a concise YAML with keys: moves (list of {from, to}), notes (short bullets), and toc_sections (map of section -> sorted list of component folder names). Only include safe, mechanical moves (no content edits).\n\nCurrent structure:\n${structure.map((e) => `- ${e.type}: ${e.path}`).join('\n')}\n\nComponent docs excerpts:\n${Object.entries(docs).map(([k, v]) => `### ${k}\n${v}`).join('\n\n')}`;
+  return `You are an expert frontend architect. Given the components folder structure and docs, propose an improved organization (groupings like UI, data-display, feedback, navigation), and suggest safe renames/moves. 
+
+Output a concise YAML with keys:
+- moves: list of {from, to} for safe component relocations
+- notes: detailed, actionable insights about the organization, including:
+  * Architectural recommendations
+  * Naming convention suggestions
+  * Potential improvements for maintainability
+  * Grouping rationale
+  * Future considerations
+- toc_sections: map of section -> sorted list of component folder names
+
+Only include safe, mechanical moves (no content edits). Provide comprehensive notes that explain your organizational decisions and provide actionable insights for developers.
+
+Current structure:
+${structure.map((e) => `- ${e.type}: ${e.path}`).join('\n')}
+
+Component docs excerpts:
+${Object.entries(docs).map(([k, v]) => `### ${k}\n${v}`).join('\n\n')}`;
 }
 
 async function callGemini(prompt) {
@@ -241,9 +259,7 @@ async function main() {
     if (githubOutput) {
       const fs = await import('fs');
       const output = [
-        `changes_made=${appliedMoves.length > 0 ? 'true' : 'false'}`,
-        `summary_path=${summaryPath}`,
-        `markdown_path=${markdownPath}`
+        `changes_made=${appliedMoves.length > 0 ? 'true' : 'false'}`
       ].join('\n');
       fs.writeFileSync(githubOutput, output, 'utf8');
     }


### PR DESCRIPTION
Display AI notes directly in the workflow comment instead of as downloadable artifacts.

The previous implementation required users to download a `.zip` artifact to view the detailed AI notes and summary. This PR integrates all the information directly into the GitHub commit comment, making it immediately accessible and improving the developer experience. It also enhances the AI prompt for more detailed notes and adds better formatting to the comment.

---
<a href="https://cursor.com/background-agent?bcId=bc-d7947684-2981-4255-800a-ae0f8f3f1165">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d7947684-2981-4255-800a-ae0f8f3f1165">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

